### PR TITLE
Require Julia >= 1.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Singular = "bcd08a7b-43d2-5ff7-b6d4-c458787f915c"
 #LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e" ## needed by JuliaExperimental
 
 [compat]
-julia = "1.1, 1.2, 1.3, 1.4"
+julia = "1.3"
 GAP = "^0"
 Singular = "^0.2"
 


### PR DESCRIPTION
... as that it is what GAP.jl requires. Also note that `julia = "1.3"`
really means all 1.x versions >= 1.3